### PR TITLE
Fix Typos in scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ This project demonstrates how to use the fxPortal contracts to transfer ERC20 to
 
 1. Run npm i to install dependencies
 2. Put your private key in the .env.examples file and rename to .env when finished
-3. Run npx hardhat run scipts/deploy.js --network goerli to deploy ERC20 contract
+3. Run npx hardhat run scripts/deploy.js --network goerli to deploy ERC20 contract
 4. Paste the newly deployed contract address in the tokenAddress variable for the other scripts
 5. Make sure to fill in your public key
-6. Run npx hardhat run scipts/mint.js --network goerli to mint tokens to your wallet
-7. Run npx hardhat run scipts/approveDeposit.js --network goerli to approve and deposit your tokens to polygon
+6. Run npx hardhat run scripts/mint.js --network goerli to mint tokens to your wallet
+7. Run npx hardhat run scripts/approveDeposit.js --network goerli to approve and deposit your tokens to polygon
 8. Wait 20-30ish minutes for tokens to show on polygon account
 9. Use polyscan.com to check your account for the tokens. Once they arrive, you can click on the transaction to get the contract address for polygon.
 10. Use this polygon contract address for your getBalance script's tokenAddress
-11. Run npx hardhat run scipts/getBalance.js --network mumbai to see the new polygon balance
+11. Run npx hardhat run scripts/getBalance.js --network mumbai to see the new polygon balance


### PR DESCRIPTION
Fixed readme commands by changing scipts/foo.js to scripts/foo.js